### PR TITLE
Create a switch Button

### DIFF
--- a/src/components/WOISwitchButton/index.tsx
+++ b/src/components/WOISwitchButton/index.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import styled from "styled-components";
+
+interface WOISwitchButtonProps {
+    trackWidth: number
+    trackHeight: number
+    padding?: number
+    trackBorderRadius?: number
+    trackBorderColor?: string
+    trackBorderWidth?: number
+    trackActiveColor?: string
+    trackInActiveColor?: string
+    thumbSize: number
+    thumbBorderRadius?: number
+    thumbBorderColor?: string
+    thumbBorderWidth?: number
+    thumbActiveColor?: string
+    thumbInActiveColor?: string
+    isActive: boolean,
+    thumbIconSize?: number
+    thumbActiveIcon?: string
+    thumbInActiveIcon?: string
+}
+
+const WOISwitchButton = (props: WOISwitchButtonProps) => {
+    const { trackWidth, trackHeight, padding, trackBorderRadius, trackBorderColor, trackBorderWidth, trackActiveColor, trackInActiveColor, thumbSize, thumbBorderRadius, thumbBorderColor, thumbBorderWidth, thumbActiveColor, thumbInActiveColor, isActive, thumbIconSize, thumbActiveIcon, thumbInActiveIcon } = props;
+    const [toggled, setToggled] = useState(false);
+
+    useEffect(() => {
+        setToggled(isActive);
+    }, [isActive]);
+
+    // add animation to the slider
+    const TrackWidget = styled.div`
+        width: ${trackWidth}px;
+        height: ${trackHeight}px;
+        background-color: ${toggled ? trackActiveColor : trackInActiveColor};
+        border-radius: ${trackBorderRadius}px;
+        position: relative;
+        padding: ${padding}px;
+        border-color: ${trackBorderColor};
+        border-style: solid;
+        border-width: ${trackBorderWidth}px;
+        cursor: pointer;
+        transition: background-color 1s ease;
+    `;
+
+    const handleToggle = () => setToggled(!toggled);
+
+    const ThumbWidget = styled.div`
+        width: ${thumbSize}px;
+        height: ${thumbSize}px;
+        background-color: ${toggled ? thumbActiveColor : thumbInActiveColor};
+        border-radius: ${thumbBorderRadius}%;
+        border-color: ${thumbBorderColor};
+        border-style: solid;
+        border-width: ${thumbBorderWidth}px;
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%) translateX(${toggled ? (trackWidth - thumbSize - 2) + 'px' : '-2px'});
+        transition: 1s;
+    `;
+
+    return (
+        <TrackWidget onClick={handleToggle}>
+            <ThumbWidget>
+                {(!toggled && thumbInActiveIcon) && <img src={thumbInActiveIcon} alt='inactive thumb icon' height={thumbIconSize} width={thumbIconSize} style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />}
+                {(toggled && thumbActiveIcon) && <img src={thumbActiveIcon} alt='active thumb icon' height={thumbIconSize} width={thumbIconSize} style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />}
+            </ThumbWidget>
+        </TrackWidget>
+    );
+};
+
+export default WOISwitchButton;

--- a/src/docs/woi-switch-button.mdx
+++ b/src/docs/woi-switch-button.mdx
@@ -1,0 +1,23 @@
+# WOI Switch Button Component
+
+WOI switch button component is a reusable React component for creating interactive buttons in your web application.
+
+## Props
+
+WOI Switch Button component accepts the following props:
+
+- `trackWidth` (number): The width of the track, specified as a numerical value (e.g., pixels) or as a percentage of its container's width.
+- `trackHeight` (number): The height of the track, specified as a numerical value (e.g., pixels) or as a percentage of its container's height.
+- `padding` (number): Padding is used to create space around an element's content, inside of any defined borders.
+- `trackBorderRadius` (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
+- `trackBorderColor` (string): The border-color property is used to set the color of the four borders. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `trackBorderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `trackActiveColor` (string):  The active color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `trackInActiveColor` (string):  The active color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbSize` (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) or as a percentage of its container's width and height.
+- `thumbBorderRadius` (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
+- `thumbBorderColor` (string): The border-color property is used to set the color of the four borders. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbBorderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `thumbActiveColor` (string): The active color property is used to set the color of the thumb in active state. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbInActiveColor` (string): The inactive color property is used to set the color of the thumb in inactive state. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `isActive` (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.

--- a/src/stories/woi-switch-button.stories.ts
+++ b/src/stories/woi-switch-button.stories.ts
@@ -1,0 +1,31 @@
+
+import WOISwitchButton from '../components/WOISwitchButton';
+
+export default {
+    title: 'WOI Switch Button',
+    component: WOISwitchButton,
+    tags: ['autodocs'],
+};
+
+export const Default = {
+    args: {
+        trackWidth: 60,
+        trackHeight: 24,
+        padding: 4,
+        trackBorderRadius: 50,
+        trackBorderColor: '#33B8FF',
+        trackBorderWidth: 2,
+        trackActiveColor: '#33B8FF',
+        trackInActiveColor: '#D3D3D3',
+        thumbSize: 24,
+        thumbBorderRadius: 50,
+        thumbBorderColor: '#FFFFFF',
+        thumbBorderWidth: 2,
+        thumbActiveColor: '#FFFFFF',
+        thumbInActiveColor: '#D3D3D3',
+        isActive: false,
+        thumbActiveIcon: 'https://cdn-icons-png.flaticon.com/512/1400/1400310.png',
+        thumbInActiveIcon: 'https://cdn-icons-png.flaticon.com/512/4445/4445942.png',
+        thumbIconSize: 20
+    },
+};


### PR DESCRIPTION
In react storybook, i have added a new component called 'WOI Switch Button'. A toggle, in general computing, is a switch between one setting and another.

This component is consist of these props:
trackWidth
trackHeight
padding
trackBorderRadius
trackBorderColor
trackBorderWidth
trackActiveColor
trackInActiveColor
thumbSize
thumbBorderRadius
thumbBorderColor
thumbBorderWidth
thumbActiveColor
thumbInActiveColor
isActive
thumbIconSize
thumbActiveIcon
thumbInActiveIcon

Covered all cases with the switch button as described in notion document.
https://www.notion.so/weoveri/Switches-Radio-Buttons-and-Check-Boxes-76a6778b012e46228dc50354fcaf0b32