### PR TITLE
Farooq/radio checkbox

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -6,7 +6,7 @@ We Over I button components are reusable React components for creating interacti
 
 - [We Over I Button Components](#we-over-i-button-components)
   - [Components](#components)
-  - [WOI Storybook](https://woi-react-storybook.netlify.app/)
+  - [WOI Storybook](#woi-storybook)
   - [**Getting Started**](#getting-started)
     - [WOI Text Button](#woi-text-button)
     - [**Usage**](#usage)
@@ -14,6 +14,12 @@ We Over I button components are reusable React components for creating interacti
     - [**Icon Button Usage**](#icon-button-usage)
     - [WOI Parallelogram Button](#woi-parallelogram-button)
     - [**Parallelogram Button Usage**](#parallelogram-button-usage)
+    - [WOI CheckBox](#woi-checkbox)
+    - [**Checkbox Usage**](#checkbox-usage)
+    - [WOI Radio Button](#woi-radio-button)
+    - [**Radio Button Usage**](#radio-button-usage)
+    - [WOI Switch Button](#woi-switch-button)
+    - [**Switch Button Usage**](#switch-button-usage)
 
 
 ## WOI Storybook 
@@ -200,5 +206,125 @@ const textButtonWidget = () => {
         prefixIcon="https://cdn-icons-png.flaticon.com/512/271/271220.png"
         suffixIcon="https://cdn-icons-png.flaticon.com/512/32/32213.png"
     />
+};
+```
+
+### WOI CheckBox
+
+WOI CheckBox component accepts the following props:
+
+
+| Props                   | Type    |
+| ----------------------- | ------- |
+| size                    | Number  |
+| borderRadius            | Number  |
+| borderWidth             | Number  |
+| activeBorderColor       | String  |
+| inActiveBorderColor     | String  |
+| activeBackgroundColor   | String  |
+| inActiveBackgroundColor | String  |
+| icon                    | String  |
+| iconSize                | Number  |
+| OnClick                 | Boolean |
+
+
+### **Checkbox Usage**
+
+```js
+import {WOICheckBox} from "woi-react-storybook/buttons";
+
+const WOICheckBoxWidget = () => {
+  <WOICheckBox
+    size={32}
+    borderRadius={8}
+    borderWidth={3}
+    activeBorderColor="#33B8FF"
+    inActiveBorderColor ="#D3D3D3"
+    activeBackgroundColor="#FFFFFF"
+    inActiveBackgroundColor= "#FFFFFF"
+    icon= "https://cdn-icons-png.flaticon.com/512/3106/3106690.png"
+    iconSize={36}
+    isChecked={false}
+  />;
+};
+```
+### WOI Radio Button
+
+WOI Radio Button component accepts the following props:
+
+
+| Props               | Type     |
+| ------------------- | -------- |
+| size                | Number   |
+| borderWidth         | Number   |
+| activeBorderColor   | String   |
+| inActiveBorderColor | String   |
+| activeColor         | String   |
+| inActiveColor       | String   |
+| isSelected          | Boolean  |
+| OnClick             | Function |
+
+
+### **Radio Button Usage**
+
+```js
+import {WOIRadioButton} from "woi-react-storybook/buttons";
+
+const WOIRadioButtonWidget = () => {
+  <WOIRadioButton
+    size={24}
+    activeBorderColor="#33B8FF"
+    inActiveBorderColor= "#D3D3D3"
+    borderWidth={2}
+    activeColor="#33B8FF"
+    inActiveColor="#D3D3D3"
+    isSelected={false}
+  />;
+};
+```
+
+### WOI Switch Button
+
+WOI Switch Button component accepts the following props:
+
+
+| Props               | Type     |
+| ------------------- | -------- |
+| size                | Number   |
+| borderWidth         | Number   |
+| activeBorderColor   | String   |
+| inActiveBorderColor | String   |
+| activeColor         | String   |
+| inActiveColor       | String   |
+| isSelected          | Boolean  |
+| OnClick             | Function |
+
+
+### **Switch Button Usage**
+
+```js
+import {WOISwitchButton} from "woi-react-storybook/buttons";
+
+const WOISwitchButtonWidget = () => {
+  <WOISwitchButton
+    trackWidth={60}
+    trackHeight={24}
+    padding={4}
+    trackBorderRadius={50}
+    trackBorderColor="#33B8FF"
+    trackBorderWidth={2}
+    trackActiveColor="#33B8FF"
+    trackInActiveColor="#D3D3D3"
+    thumbSize={24}
+    thumbBorderRadius={50}
+    thumbBorderColor="#FFFFFF"
+    thumbBorderWidth={2}
+    thumbActiveColor="#FFFFFF"
+    thumbInActiveColor="#D3D3D3"
+    isActive={false}
+    thumbActiveIcon="https://cdn-icons-png.flaticon.com/512/1400/1400310.png"
+    thumbInActiveIcon="https://cdn-icons-png.flaticon.com/512/4445/4445942.png"
+    thumbIconSize={20}
+  />;
 };
 ```

--- a/src/components/WOICheckBox/index.tsx
+++ b/src/components/WOICheckBox/index.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+interface WOISwitchButtonProps {
+    size: number
+    borderRadius?: number
+    borderWidth?: number
+    activeBorderColor?: string
+    inActiveBorderColor?: string
+    activeBackgroundColor?: string
+    inActiveBackgroundColor?: string
+    icon?: string
+    iconSize?: number
+    isChecked: boolean
+}
+
+const WOICheckBox = (props: WOISwitchButtonProps) => {
+    const { size, borderRadius, borderWidth, activeBorderColor, inActiveBorderColor, activeBackgroundColor, inActiveBackgroundColor, icon, iconSize, isChecked } = props;
+    const [toggled, setToggled] = useState(false);
+
+    useEffect(() => {
+        setToggled(isChecked);
+    }, [isChecked]);
+
+    const CheckboxWidget = styled.div`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 4px;
+        height: ${size}px;
+        width: ${size}px;
+        cursor: pointer;
+        border-style: solid;
+        border-width: ${borderWidth}px;
+        border-radius: ${borderRadius}px;
+        border-color: ${toggled ? activeBorderColor : inActiveBorderColor};
+        background-color: ${toggled ? activeBackgroundColor : inActiveBackgroundColor};
+    `;
+
+    const handleToggle = () => { console.log('clicked'); setToggled(!toggled); }
+
+    return (
+        <CheckboxWidget onClick={handleToggle}>
+            {(toggled && icon) && <img src={icon} alt='icon' height={iconSize} width={iconSize} />}
+        </CheckboxWidget>
+    );
+};
+
+export default WOICheckBox;

--- a/src/components/WOIRadioButton/index.tsx
+++ b/src/components/WOIRadioButton/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import styled from "styled-components";
+
+interface WOIRadioButtonProps {
+    size: number
+    activeBorderColor?: string
+    inActiveBorderColor?: string
+    borderWidth?: number
+    activeColor?: string
+    inActiveColor?: string
+    isSelected: boolean
+}
+
+const WOIRadioButton = (props: WOIRadioButtonProps) => {
+    const { size, activeBorderColor, inActiveBorderColor, borderWidth, activeColor, inActiveColor, isSelected } = props;
+    const [toggled, setToggled] = useState(false);
+
+    useEffect(() => {
+        setToggled(isSelected);
+    }, [isSelected]);
+
+    // add animation to the slider
+    const OuterWidget = styled.div`
+        width: ${size}px;
+        height: ${size}px;
+        background-color: #FFFFFF;
+        border-radius: 100%;
+        padding: 3px;
+        border-color: ${toggled ? activeColor : inActiveColor};
+        border-style: solid;
+        border-width: ${borderWidth}px;
+        cursor: pointer;
+    `;
+
+    const handleToggle = () => setToggled(!toggled);
+
+    const InnerWidget = styled.div`
+        width: ${size - 4}px;
+        height: ${size - 4}px;
+        background-color: ${toggled ? activeBorderColor : inActiveBorderColor};
+        border-radius: 100%;
+        border-color: ${toggled ? activeColor : inActiveColor};
+        border-style: solid;
+        border-width: ${borderWidth}px;
+        position: absolute;
+    `;
+
+    return (
+        <OuterWidget onClick={handleToggle}>
+            <InnerWidget />
+        </OuterWidget>
+    );
+};
+
+export default WOIRadioButton;

--- a/src/components/WOISwitchButton/index.tsx
+++ b/src/components/WOISwitchButton/index.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import styled from "styled-components";
+
+interface WOISwitchButtonProps {
+    trackWidth: number
+    trackHeight: number
+    padding?: number
+    trackBorderRadius?: number
+    trackBorderColor?: string
+    trackBorderWidth?: number
+    trackActiveColor?: string
+    trackInActiveColor?: string
+    thumbSize: number
+    thumbBorderRadius?: number
+    thumbBorderColor?: string
+    thumbBorderWidth?: number
+    thumbActiveColor?: string
+    thumbInActiveColor?: string
+    isActive: boolean,
+    thumbIconSize?: number
+    thumbActiveIcon?: string
+    thumbInActiveIcon?: string
+}
+
+const WOISwitchButton = (props: WOISwitchButtonProps) => {
+    const { trackWidth, trackHeight, padding, trackBorderRadius, trackBorderColor, trackBorderWidth, trackActiveColor, trackInActiveColor, thumbSize, thumbBorderRadius, thumbBorderColor, thumbBorderWidth, thumbActiveColor, thumbInActiveColor, isActive, thumbIconSize, thumbActiveIcon, thumbInActiveIcon } = props;
+    const [toggled, setToggled] = useState(false);
+
+    useEffect(() => {
+        setToggled(isActive);
+    }, [isActive]);
+
+    // add animation to the slider
+    const TrackWidget = styled.div`
+        width: ${trackWidth}px;
+        height: ${trackHeight}px;
+        background-color: ${toggled ? trackActiveColor : trackInActiveColor};
+        border-radius: ${trackBorderRadius}px;
+        position: relative;
+        padding: ${padding}px;
+        border-color: ${trackBorderColor};
+        border-style: solid;
+        border-width: ${trackBorderWidth}px;
+        cursor: pointer;
+        transition: background-color 1s ease;
+    `;
+
+    const handleToggle = () => setToggled(!toggled);
+
+    const ThumbWidget = styled.div`
+        width: ${thumbSize}px;
+        height: ${thumbSize}px;
+        background-color: ${toggled ? thumbActiveColor : thumbInActiveColor};
+        border-radius: ${thumbBorderRadius}%;
+        border-color: ${thumbBorderColor};
+        border-style: solid;
+        border-width: ${thumbBorderWidth}px;
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%) translateX(${toggled ? (trackWidth - thumbSize - 2) + 'px' : '-2px'});
+        transition: 1s;
+    `;
+
+    return (
+        <TrackWidget onClick={handleToggle}>
+            <ThumbWidget>
+                {(!toggled && thumbInActiveIcon) && <img src={thumbInActiveIcon} alt='inactive thumb icon' height={thumbIconSize} width={thumbIconSize} style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />}
+                {(toggled && thumbActiveIcon) && <img src={thumbActiveIcon} alt='active thumb icon' height={thumbIconSize} width={thumbIconSize} style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />}
+            </ThumbWidget>
+        </TrackWidget>
+    );
+};
+
+export default WOISwitchButton;

--- a/src/docs/woi-checkbox.mdx
+++ b/src/docs/woi-checkbox.mdx
@@ -1,0 +1,18 @@
+# WOI Checkbox Component
+
+WOI checkbox component is a reusable React component for creating interactive buttons in your web application.
+
+## Props
+
+WOI Checkbox component accepts the following props:
+
+- `size` (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) or as a percentage of its container's width and height.
+- `borderRadius` (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
+- `borderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `activeBorderColor` (string):  The color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `inActiveBorderColor` (string):  The color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `activeBackgroundColor` (string):  The color property is used to set the background color of the container in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `inActiveBackgroundColor` (string):  The color property is used to set the background color of the container in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `icon` (string): An icon or image that appears before the button's text. It can be specified as a path to an icon file or a CSS class for an icon font.
+- `iconSize` (number): The height and width of the icon, specified as a numerical value (e.g., pixels) or as a percentage of its container's width and height.
+- `isChecked` (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.

--- a/src/docs/woi-radio-button.mdx
+++ b/src/docs/woi-radio-button.mdx
@@ -1,0 +1,15 @@
+# WOI Radio Button Component
+
+WOI radio button component is a reusable React component for creating interactive buttons in your web application.
+
+## Props
+
+WOI Radio Button component accepts the following props:
+
+- `size` (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) or as a percentage of its container's width and height.
+- `activeBorderColor` (string):  The color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `inActiveBorderColor` (string):  The color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `borderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `activeColor` (string):  The color property is used to set the background color of the container in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `inActiveColor` (string):  The color property is used to set the background color of the container in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `isSelected` (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.

--- a/src/docs/woi-switch-button.mdx
+++ b/src/docs/woi-switch-button.mdx
@@ -1,0 +1,23 @@
+# WOI Switch Button Component
+
+WOI switch button component is a reusable React component for creating interactive buttons in your web application.
+
+## Props
+
+WOI Switch Button component accepts the following props:
+
+- `trackWidth` (number): The width of the track, specified as a numerical value (e.g., pixels) or as a percentage of its container's width.
+- `trackHeight` (number): The height of the track, specified as a numerical value (e.g., pixels) or as a percentage of its container's height.
+- `padding` (number): Padding is used to create space around an element's content, inside of any defined borders.
+- `trackBorderRadius` (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
+- `trackBorderColor` (string): The border-color property is used to set the color of the four borders. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `trackBorderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `trackActiveColor` (string):  The active color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `trackInActiveColor` (string):  The active color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbSize` (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) or as a percentage of its container's width and height.
+- `thumbBorderRadius` (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
+- `thumbBorderColor` (string): The border-color property is used to set the color of the four borders. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbBorderWidth` (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels) or as a percentage.
+- `thumbActiveColor` (string): The active color property is used to set the color of the thumb in active state. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `thumbInActiveColor` (string): The inactive color property is used to set the color of the thumb in inactive state. The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
+- `isActive` (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.

--- a/src/stories/woi-checkbox.stories.ts
+++ b/src/stories/woi-checkbox.stories.ts
@@ -1,0 +1,22 @@
+import WOICheckBox from "../components/WOICheckBox";
+
+export default {
+    title: 'WOI Checkbox',
+    component: WOICheckBox,
+    tags: ['autodocs'],
+};
+
+export const Default = {
+    args: {
+        size: 32,
+        borderRadius: 8,
+        borderWidth: 3,
+        activeBorderColor: '#33B8FF',
+        inActiveBorderColor: '#D3D3D3',
+        activeBackgroundColor: '#FFFFFF',
+        inActiveBackgroundColor: '#FFFFFF',
+        icon: 'https://cdn-icons-png.flaticon.com/512/3106/3106690.png',
+        iconSize: 36,
+        isChecked: false,
+    },
+};

--- a/src/stories/woi-radio-button.stories.ts
+++ b/src/stories/woi-radio-button.stories.ts
@@ -1,0 +1,19 @@
+import WOIRadioButton from "../components/WOIRadioButton";
+
+export default {
+    title: 'WOI Radio Button',
+    component: WOIRadioButton,
+    tags: ['autodocs'],
+};
+
+export const Default = {
+    args: {
+        size: 24,
+        activeBorderColor: '#33B8FF',
+        inActiveBorderColor: '#D3D3D3',
+        borderWidth: 2,
+        activeColor: '#33B8FF',
+        inActiveColor: '#D3D3D3',
+        isSelected: false,
+    },
+};

--- a/src/stories/woi-switch-button.stories.ts
+++ b/src/stories/woi-switch-button.stories.ts
@@ -1,0 +1,31 @@
+
+import WOISwitchButton from '../components/WOISwitchButton';
+
+export default {
+    title: 'WOI Switch Button',
+    component: WOISwitchButton,
+    tags: ['autodocs'],
+};
+
+export const Default = {
+    args: {
+        trackWidth: 60,
+        trackHeight: 24,
+        padding: 4,
+        trackBorderRadius: 50,
+        trackBorderColor: '#33B8FF',
+        trackBorderWidth: 2,
+        trackActiveColor: '#33B8FF',
+        trackInActiveColor: '#D3D3D3',
+        thumbSize: 24,
+        thumbBorderRadius: 50,
+        thumbBorderColor: '#FFFFFF',
+        thumbBorderWidth: 2,
+        thumbActiveColor: '#FFFFFF',
+        thumbInActiveColor: '#D3D3D3',
+        isActive: false,
+        thumbActiveIcon: 'https://cdn-icons-png.flaticon.com/512/1400/1400310.png',
+        thumbInActiveIcon: 'https://cdn-icons-png.flaticon.com/512/4445/4445942.png',
+        thumbIconSize: 20
+    },
+};


### PR DESCRIPTION
In react storybook, i have added two new component called 'WOI Radio Button' and 'WOI Checkbox'.

Radio Button properties:
- size (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) of its container's width and height.
- activeBorderColor (string):  The color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- inActiveBorderColor (string):  The color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- borderWidth (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels).
- activeColor (string):  The color property is used to set the background color of the container in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- inActiveColor (string):  The color property is used to set the background color of the container in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- isSelected (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.
 
Checkbox properties:
- size (number): (number): The width and height of the thumb, specified as a numerical value (e.g., pixels) of its container's width and height.
- activeBorderColor (string):  The color property is used to set the color of the track in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- inActiveBorderColor`(string):  The color property is used to set the color of the track in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- borderWidth (number): The border-width property sets the width of an element's borders. Specified as a numerical value (e.g., pixels).
- activeBackgroundColor (string):  The color property is used to set the background color of the container in active state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- inActiveBackgroundColor (string):  The color property is used to set the background color of the container in inactive state.  The color can be set by: name - specify a color name, like "red", Hex code (#RRGGBB), and RGB color (rgb(R, G, B)).
- isChecked (boolean): A boolean flag that determines whether the button is in a disabled state. When set to true, the button is not clickable or interactive.
- borderRadius: (number): The borderRadius CSS property rounds the corners of an element's outer border edge. You can set a single radius to make circular corners, or two radii to make elliptical corners.
- icon (string): An icon or image that appears before the button's text. It can be specified as a path to an icon file or a CSS class for an icon font.
- iconSize (number): The height and width of the icon, specified as a numerical value (e.g., pixels) of its container's width and height.



Covered all cases with and properties with radio button and checkbox as described in notion document.
https://www.notion.so/weoveri/Switches-Radio-Buttons-and-Check-Boxes-76a6778b012e46228dc50354fcaf0b32